### PR TITLE
indices dicts are now str -> Tensor, not Dim -> Tensor

### DIFF
--- a/alan_simplified/Sample.py
+++ b/alan_simplified/Sample.py
@@ -296,11 +296,12 @@ class Sample():
         
         
     def index_in(self, post_idxs: dict[Dim, Tensor], Ndim: Dim):
-        '''Takes a sample (nested dict of tensors with Kdims) and a dictionary of Kdims to indices.
-        Returns a new sample (nested dict of tensors with Ndims instead of Kdims) with the indices
-        applied to the sample.'''
+        '''Takes a sample (nested dict of tensors with Kdims) and a dictionary of dim names (i.e. strings) 
+        to indices. Returns a new sample (nested dict of tensors with Ndims instead of Kdims) with the 
+        indices applied to the sample.'''
+        dim_idxs = {self.groupvarname2Kdim[name[2:]]: idx for (name, idx) in post_idxs.items()}
 
-        return index_into_sample(self.sample, post_idxs, Ndim)
+        return index_into_sample(self.sample, dim_idxs, Ndim)
     
     def clone_sample(self, sample: dict):
         '''Takes a sample (nested dict of tensors) and returns a new dict with the same structure

--- a/alan_simplified/reduce_Ks.py
+++ b/alan_simplified/reduce_Ks.py
@@ -31,8 +31,7 @@ def einsum_args(lps, sum_dims):
     return [val for pair in zip(undim_lps, arg_idxs) for val in pair] + [out_idxs], out_dims
 
 
-def sample_Ks(lps, Ks_to_sum, N_dim, num_samples):
-
+def sample_Ks(lps, Ks_to_sum, N_dim, num_samples, groupvarname2Kdim):
     """
     Fundamental method that returns K samples from the posterior
     opt_einsum gives an "optimization path", i.e. the indicies of lps to reduce.
@@ -50,8 +49,8 @@ def sample_Ks(lps, Ks_to_sum, N_dim, num_samples):
     for lps, kdims_to_sample in zip(lps_for_sampling[::-1], Ks_to_sample[::-1]): 
         lp = sum(lps)
 
-        for dim in list(set(generic_dims(lp)).intersection(set(indices.keys()))):
-            lp = lp.order(dim)[indices[dim]]
+        for dim in list(set(generic_dims(lp)).intersection(set([groupvarname2Kdim[name[2:]] for name in indices.keys()]))):
+            lp = lp.order(dim)[indices[str(dim)]]
         
         #If there is more than one Kdim to sample from this factor we need to sample from the joint distribution
         #To do this we sample from a multinomial over the indices of the lp tensor
@@ -64,7 +63,7 @@ def sample_Ks(lps, Ks_to_sum, N_dim, num_samples):
         unravelled_indices = unravel_index(sampled_flat_idx, shape=[dim.size for dim in kdims_to_sample])
         
         for idx, kdim in zip(unravelled_indices, kdims_to_sample):
-            indices[kdim] = idx[N_dim]
+            indices[str(kdim)] = idx[N_dim]
 
                 
         #Otherwise we can just sample from the multinomial with probabilities given by the Kdim dimension of the lp tensor

--- a/alan_simplified/sample_logpq.py
+++ b/alan_simplified/sample_logpq.py
@@ -12,7 +12,6 @@ from .dist import Dist
 from .logpq import logPQ_dist, logPQ_group, logPQ_plate, lp_getter
 from .Data import Data
 
-PBP = Union[Plate, BoundPlate]
 
 def logPQ_sample(
     name:Optional[str],
@@ -64,12 +63,12 @@ def logPQ_sample(
 
     # Index into each lp with the indices we've collected so far
     for i in range(len(lps)):
-        for dim in list(set(generic_dims(lps[i])).intersection(set(indices.keys()))):
-            lps[i] = lps[i].order(dim)[indices[dim]]
+        for dim in list(set(generic_dims(lps[i])).intersection(set([groupvarname2Kdim[name[2:]] for name in indices.keys()]))):
+            lps[i] = lps[i].order(dim)[indices[str(dim)]]
 
 
     if len(all_Ks) > 0:
-        indices = {**indices, **sample_Ks(lps, all_Ks,N_dim, num_samples)}
+        indices = {**indices, **sample_Ks(lps, all_Ks, N_dim, num_samples, groupvarname2Kdim)}
         
     for childname, childP in P.prog.items():
         childQ = Q.prog.get(childname)


### PR DESCRIPTION
As per the README todo: "logPQ_sample should return a dict[str, Tensor], with str representing variable name (mainly because we can always map from str to Dim, but we can't reliably go back)"

However, I'm not sure this is a better situation than before: the only real differences are that instead of just using `indices.keys()` directly to access dims (and use those as keys) we have to keep track of `groupvarname2Kdim` in `logPQ_sample` and `sample_Ks`, which also involves an odd-looking `name[2:]` to convert between `str(dim)` (e.g. `"K_alpha"`) and the keys in `groupvarname2Kdim` (which don't have the `"K_"` prefix, e.g. just `"alpha"`).